### PR TITLE
Fix general crashes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ android {
         applicationId "io.smileyjoe.putio.tv"
         minSdkVersion 26
         targetSdkVersion 31
-        versionCode 29
-        versionName "3.3.1." + getBuildNumber()
+        versionCode 30
+        versionName "3.3.2." + getBuildNumber()
         buildConfigField "String", "PUTIO_CLIENT_ID", "\"${putio_client_id}\""
         buildConfigField "String", "PUTIO_CLIENT_SECRET", "\"${putio_client_secret}\""
         buildConfigField "String", "TMDB_AUTH_TOKEN", "\"${tmdb_auth_token}\""

--- a/app/src/main/java/io/smileyjoe/putio/tv/channel/Programmes.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/channel/Programmes.java
@@ -44,7 +44,7 @@ public class Programmes {
                     .orElse(null);
 
             if (video.getVideoType() == VideoType.MOVIE && timeLeft <= 600000) {
-                if(program != null) {
+                if (program != null) {
                     helper.deletePreviewProgram(program.getId());
                 }
                 return;

--- a/app/src/main/java/io/smileyjoe/putio/tv/channel/Programmes.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/channel/Programmes.java
@@ -44,7 +44,9 @@ public class Programmes {
                     .orElse(null);
 
             if (video.getVideoType() == VideoType.MOVIE && timeLeft <= 600000) {
-                helper.deletePreviewProgram(program.getId());
+                if(program != null) {
+                    helper.deletePreviewProgram(program.getId());
+                }
                 return;
             } else {
                 // Remove older items //

--- a/app/src/main/java/io/smileyjoe/putio/tv/comparator/VideoComparator.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/comparator/VideoComparator.java
@@ -5,7 +5,6 @@ import java.util.stream.Stream;
 
 import io.smileyjoe.putio.tv.object.Filter;
 import io.smileyjoe.putio.tv.object.Video;
-import io.smileyjoe.putio.tv.object.VideoType;
 
 public class VideoComparator implements Comparator<Video> {
 

--- a/app/src/main/java/io/smileyjoe/putio/tv/ui/adapter/BaseListAdapter.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/ui/adapter/BaseListAdapter.java
@@ -52,7 +52,7 @@ public abstract class BaseListAdapter<T, U extends BaseViewHolder<T, ? extends V
     public void setItems(ArrayList<T> items) {
         int oldSize = getItemCount();
 
-        if(items != null){
+        if (items != null) {
             mItems = items;
         } else {
             mItems = new ArrayList<>();
@@ -60,16 +60,16 @@ public abstract class BaseListAdapter<T, U extends BaseViewHolder<T, ? extends V
 
         int newSize = getItemCount();
 
-        if(newSize == 0) {
+        if (newSize == 0) {
             notifyItemRangeRemoved(0, oldSize);
         } else if (oldSize == 0) {
             notifyItemRangeInserted(0, newSize);
-        } else if(oldSize == newSize) {
+        } else if (oldSize == newSize) {
             notifyItemRangeChanged(0, newSize);
-        } else if(newSize > oldSize){
+        } else if (newSize > oldSize) {
             notifyItemRangeChanged(0, oldSize);
             notifyItemRangeInserted(oldSize, newSize);
-        } else if(oldSize > newSize) {
+        } else if (oldSize > newSize) {
             notifyItemRangeChanged(0, newSize);
             notifyItemRangeRemoved(newSize, oldSize);
         }

--- a/app/src/main/java/io/smileyjoe/putio/tv/ui/adapter/BaseListAdapter.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/ui/adapter/BaseListAdapter.java
@@ -50,7 +50,29 @@ public abstract class BaseListAdapter<T, U extends BaseViewHolder<T, ? extends V
     }
 
     public void setItems(ArrayList<T> items) {
-        mItems = items;
+        int oldSize = getItemCount();
+
+        if(items != null){
+            mItems = items;
+        } else {
+            mItems = new ArrayList<>();
+        }
+
+        int newSize = getItemCount();
+
+        if(newSize == 0) {
+            notifyItemRangeRemoved(0, oldSize);
+        } else if (oldSize == 0) {
+            notifyItemRangeInserted(0, newSize);
+        } else if(oldSize == newSize) {
+            notifyItemRangeChanged(0, newSize);
+        } else if(newSize > oldSize){
+            notifyItemRangeChanged(0, oldSize);
+            notifyItemRangeInserted(oldSize, newSize);
+        } else if(oldSize > newSize) {
+            notifyItemRangeChanged(0, newSize);
+            notifyItemRangeRemoved(newSize, oldSize);
+        }
     }
 
     public void setFragmentType(FragmentType fragmentType) {

--- a/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/FolderListFragment.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/FolderListFragment.java
@@ -80,7 +80,6 @@ public class FolderListFragment extends BaseFragment<FragmentFolderListBinding> 
             mView.recycler.setVisibility(View.VISIBLE);
 
             mAdapter.setItems(folders);
-            mAdapter.notifyDataSetChanged();
         }
     }
 

--- a/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/GenreListFragment.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/GenreListFragment.java
@@ -71,7 +71,6 @@ public class GenreListFragment extends BaseFragment<FragmentGenreListBinding> {
 
     public void setGenres(ArrayList<Genre> genres) {
         mAdapter.setItems(genres);
-        mAdapter.notifyDataSetChanged();
     }
 
     public void setGenreIds(ArrayList<Integer> genreIds) {

--- a/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/SubtitleFragment.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/SubtitleFragment.java
@@ -119,7 +119,6 @@ public class SubtitleFragment extends BaseFragment<FragmentSubtitleBinding> impl
                     subtitles.add(0, subtitleEmpty);
 
                     mAdapter.setItems(subtitles);
-                    mAdapter.notifyDataSetChanged();
 
                     mView.recyclerSubtitle.setVisibility(View.VISIBLE);
                     mView.textEmpty.setVisibility(View.GONE);

--- a/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/VideosFragment.java
+++ b/app/src/main/java/io/smileyjoe/putio/tv/ui/fragment/VideosFragment.java
@@ -128,7 +128,6 @@ public class VideosFragment extends BaseFragment<FragmentVideoListBinding> {
     }
 
     private void populate() {
-        int oldSize = mVideosAdapter.getItemCount();
         ArrayList<Video> videos = applyFilters();
 
         if (videos == null || videos.isEmpty()) {
@@ -140,12 +139,6 @@ public class VideosFragment extends BaseFragment<FragmentVideoListBinding> {
         }
 
         mVideosAdapter.setItems(videos);
-
-        if (oldSize == 0) {
-            mVideosAdapter.notifyDataSetChanged();
-        } else {
-            mVideosAdapter.notifyItemRangeChanged(0, oldSize);
-        }
     }
 
     public void filter(Filter filter, boolean isSelected) {


### PR DESCRIPTION
- `Fatal Exception: java.lang.IndexOutOfBoundsException` could happen when filtering the grid view
- `Fatal Exception: java.lang.NullPointerException` was happening when a movie that was previosuly watched elsewhere was watched in the app